### PR TITLE
fix crash when resizing ScrollImage in OnResize event handler

### DIFF
--- a/src/starling/extensions/krecha/ScrollImage.as
+++ b/src/starling/extensions/krecha/ScrollImage.as
@@ -342,6 +342,8 @@ package starling.extensions.krecha
 			if (context == null)
 				throw new MissingContextError();
 			
+			if (context.driverInfo == "Disposed") return;
+			
 			if (mVertexBuffer)
 				mVertexBuffer.dispose();
 			if (mIndexBuffer)


### PR DESCRIPTION
it's quite common scenario with DX11 Context3D driver (every resize drop context)
DX11 driver is used in standalone player and IE
